### PR TITLE
Multi-select query params example (do not merge)

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -20,7 +20,11 @@ export const getServerSideProps = async (context) => {
     footnote = '',
     espressoAndCoffeeSubheading = '',
     espressoAndCoffeeBottomText = '',
+    multi: multiSeralized = '',
   } = context.query;
+
+  console.log(multiSeralized);
+  const multi = JSON.parse(multiSeralized);
 
   // Set the response status code to BadRequest if missing the menu query param.
   if (!menu) {
@@ -56,6 +60,7 @@ export const getServerSideProps = async (context) => {
       footnote,
       espressoAndCoffeeSubheading,
       espressoAndCoffeeBottomText,
+      multi,
     },
   };
 };
@@ -67,6 +72,7 @@ export default function Home({
   footnote,
   espressoAndCoffeeSubheading,
   espressoAndCoffeeBottomText,
+  multi,
 }) {
   const router = useRouter();
 
@@ -179,6 +185,11 @@ export default function Home({
           <div className={styles.coldbrewMenuItems}>
             {icedColdbrewData.items.slice(0, maxIcedColdbrewItems).map((i) => (
               <ColdbrewMenuItems key={i.id} {...i} />
+            ))}
+            {multi.map((x) => (
+              <pre key={x}>
+                <code>{x}</code>
+              </pre>
             ))}
           </div>
         </section>


### PR DESCRIPTION
Visit the following URL: 
http://localhost:3000?footnote=Test%0A%0ATest&espressoAndCoffeeSubheading=Subheading%20test&espressoAndCoffeeBottomText=bottom%20text%20test&multi=%5B%22my-option%22%2C%22my-second-option%22%5D&menu=3404a063-2bbe-4473-bb1b-cac3c7e1d14e

The URL above was generated by the playlist renderer [here](https://github.com/mirainc/playlist-renderer/blob/b4f5872e0fc5708ee563fea0a629b2a685aebb35/playlist-window-manager/src/embeddedApps.ts#L51).

The multi-select options should appear in the bottom right hand corner.
<img width="421" alt="image" src="https://user-images.githubusercontent.com/1712435/183550937-02d086b9-68cf-4ddb-a677-ed98ce19df38.png">
