### PR TITLE
Strip hash param to fix refresh data

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -72,7 +72,16 @@ export default function Home({
 
   useEffect(() => {
     const refreshData = () => {
-      router.replace(router.asPath);
+      // Strip hash from URL. The __raydiantWindowId hash is added by Raydiant to communicate
+      // with the Raydiant SDK for features such as Dynamic Duration. Unfortunately, this causes
+      // the browser to do a client-side navigation instead of a server-side navigation, which doesn't
+      // refresh the data. To work around this, we strip the hash from the URL before refreshing.
+      //
+      // If you need to use the Raydiant SDK with NextJS, we recommend using a library like swr or
+      // react query to handle data fetching. See this commit for an example of how to use react-query:
+      // https://github.com/mirainc/starbucks-menu-app/commit/436850c337730d4174b10cd396c177446c9c5ddb
+      const refreshUrl = router.asPath.split('#')[0];
+      router.replace(refreshUrl);
     };
 
     const id = setInterval(() => {


### PR DESCRIPTION
We released a feature a while back called [Dynamic Duration](https://developers.raydiant.com/docs/core-concepts/duration-mode#dynamic-duration), which included the new [Raydiant SDK](https://developers.raydiant.com/docs/raydiant-sdk). Apps can install the Raydiant SDK to hook into [lifecycle events](https://developers.raydiant.com/docs/core-concepts/app-lifecycle) when it's running in a playlist. The `raydiantWindowId` hash parameter was introduced to facilitate communication between apps and the device.

While the Raydiant SDK is optional, the hash parameter is always added by the device—which causes this particular issue with NextJS.

I don’t love that you need to strip out the hash parameter, we’ll be thinking of other ways we can facilitate communication with the Raydiant SDK in the future.